### PR TITLE
add option for extra HTTP headers containing checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ DisallowRedirects | Disable any mirror trying to do an HTTP redirect
 WeightDistributionRange | Multiplier of the distance to the first mirror to find other possible mirrors in order to distribute the load
 DisableOnMissingFile | Disable a mirror if an advertised file on rsync/ftp appears to be missing on HTTP
 MaxLinkHeaders | Amount of backup mirror locations returned in HTTP headers
+CheckSumHeaders | Add headers for enabled Hashes
 Fallbacks | A list of possible mirrors to use as fallback if a request fails or if the database is unreachable. **These mirrors are not tracked by mirrorbits.** It is assumed they have all the files available in the local repository.
 
 ## Running

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ var (
 		CheckInterval:          1,
 		RepositoryScanInterval: 5,
 		MaxLinkHeaders:         10,
+		CheckSumHeaders:        true,
 		Hashes: hashing{
 			SHA1:   true,
 			SHA256: false,
@@ -83,6 +84,7 @@ type Configuration struct {
 	CheckInterval           int        `yaml:"CheckInterval"`
 	RepositoryScanInterval  int        `yaml:"RepositoryScanInterval"`
 	MaxLinkHeaders          int        `yaml:"MaxLinkHeaders"`
+	CheckSumHeaders         bool       `yaml:"CheckSumHeaders"`
 	Hashes                  hashing    `yaml:"Hashes"`
 	DisallowRedirects       bool       `yaml:"DisallowRedirects"`
 	WeightDistributionRange float32    `yaml:"WeightDistributionRange"`

--- a/http/pagerenderer.go
+++ b/http/pagerenderer.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,6 +89,19 @@ func (w *RedirectRenderer) Write(ctx *Context, results *mirrors.Results) (status
 					countryCode = strings.ToLower(m.CountryFields[0])
 				}
 				ctx.ResponseWriter().Header().Add("Link", fmt.Sprintf("<%s>; rel=duplicate; pri=%d; geo=%s", m.HttpURL+path, i+1, countryCode))
+			}
+		}
+
+		// Generate checksum headers
+		if GetConfig().CheckSumHeaders {
+			if len(results.FileInfo.Md5) > 0 {
+				ctx.ResponseWriter().Header().Add("Content-MD5", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString([]byte(results.FileInfo.Md5))))
+			}
+			if len(results.FileInfo.Sha1) > 0 {
+				ctx.ResponseWriter().Header().Add("Content-SHA1", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString([]byte(results.FileInfo.Sha1))))
+			}
+			if len(results.FileInfo.Sha256) > 0 {
+				ctx.ResponseWriter().Header().Add("Content-SHA256", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString([]byte(results.FileInfo.Sha256))))
 			}
 		}
 

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -31,6 +31,7 @@ DisallowRedirects: false
 WeightDistributionRange: 1.5
 DisableOnMissingFile: false
 MaxLinkHeaders: 10
+CheckSumHeaders: true
 Fallbacks:
     - URL: http://fallback1.mirror/repo/
       CountryCode: fr


### PR DESCRIPTION
if the option CheckSumHeaders is true the following extra http headers will be added:
  Md5sum: f771b21e1297ad350479b1fcb2498e14
  Sha256sum: e4e98cc42d6380cc75334f6c7d47b2b6f959c10d18c078534cd3cdf8c991d07c
  Shasum: 28e765304479c2a69d3c6ac848f712523a3cf237