### PR TITLE
fix Content-MD5 header encoding. We must base64 endode the raw digest…

### DIFF
--- a/http/pagerenderer.go
+++ b/http/pagerenderer.go
@@ -6,6 +6,7 @@ package http
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -95,13 +96,16 @@ func (w *RedirectRenderer) Write(ctx *Context, results *mirrors.Results) (status
 		// Generate checksum headers
 		if GetConfig().CheckSumHeaders {
 			if len(results.FileInfo.Md5) > 0 {
-				ctx.ResponseWriter().Header().Add("Content-MD5", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString([]byte(results.FileInfo.Md5))))
+				md5, _ := hex.DecodeString(results.FileInfo.Md5)
+				ctx.ResponseWriter().Header().Add("Content-MD5", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString(md5)))
 			}
 			if len(results.FileInfo.Sha1) > 0 {
-				ctx.ResponseWriter().Header().Add("Content-SHA1", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString([]byte(results.FileInfo.Sha1))))
+				sha1, _ := hex.DecodeString(results.FileInfo.Sha1)
+				ctx.ResponseWriter().Header().Add("Content-SHA1", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString(sha1)))
 			}
 			if len(results.FileInfo.Sha256) > 0 {
-				ctx.ResponseWriter().Header().Add("Content-SHA256", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString([]byte(results.FileInfo.Sha256))))
+				sha256, _ := hex.DecodeString(results.FileInfo.Sha256)
+				ctx.ResponseWriter().Header().Add("Content-SHA256", fmt.Sprintf("%s", base64.URLEncoding.EncodeToString(sha256)))
 			}
 		}
 


### PR DESCRIPTION
…, not it's hex representation